### PR TITLE
`under_path()`

### DIFF
--- a/src/pywodlib/under_path.py
+++ b/src/pywodlib/under_path.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+
+
+def under_path(p1: str | os.PathLike[str], p2: str | os.PathLike[str]) -> bool:
+    """
+    Returns true iff ``p1`` (which must exist) is a path at or under the
+    directory hierarchy at ``p2`` (which may or may not exist), without
+    following any symlinks under ``p2``.  Specifically, this answers the
+    question, "If one runs ``rm -rf p2`` (after resolving trailing ``..``'s),
+    will ``p1`` cease to exist?"
+    """
+    p1 = Path(p1).resolve()
+    p2 = Path(p2).resolve()
+    try:
+        p1.relative_to(p2)
+    except ValueError:
+        return False
+    else:
+        return True

--- a/test/test_under_path.py
+++ b/test/test_under_path.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import pytest
+from pywodlib.under_path import under_path
+
+
+@pytest.fixture(scope="module")
+def faketree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    base = tmp_path_factory.mktemp("under_path")
+    (base / "foo" / "bar").mkdir(parents=True, exist_ok=True)
+    (base / "gnusto" / "cleesh").mkdir(parents=True, exist_ok=True)
+    (base / "gnusto" / "link").symlink_to(base / "foo")
+    (base / "gnusto" / "link2").symlink_to(base)
+    return base
+
+
+@pytest.mark.parametrize(
+    "p1,p2,r",
+    [
+        ("foo", "foo", True),
+        ("foo/bar", "foo", True),
+        ("foo", "foo/bar", False),
+        ("gnusto", "foo", False),
+        ("gnusto/..", "foo", False),
+        ("gnusto", "foo/..", True),
+        (".", "foo/..", True),
+        ("foo", "foo/nexist", False),
+        ("gnusto", "foo/nexist", False),
+        ("foo", "nexist", False),
+        ("gnusto/../foo/bar", "foo", True),
+        ("foo", "gnusto/link", False),  # FAIL
+        ("foo", "gnusto/link/bar", False),
+        ("foo", "gnusto/link2", False),  # FAIL
+        ("foo", "gnusto/link/..", True),
+        ("foo", "gnusto", False),
+        ("foo", "gnusto/../foo", True),
+        ("gnusto/link/bar", "gnusto", True),  # FAIL
+    ],
+)
+def test_under_path(
+    faketree: Path, monkeypatch: pytest.MonkeyPatch, p1: str, p2: str, r: bool
+) -> None:
+    monkeypatch.chdir(faketree)
+    assert under_path(p1, p2) is r
+    assert under_path(faketree / p1, p2) is r
+    assert under_path(p1, faketree / p2) is r
+    assert under_path(faketree / p1, faketree / p2) is r


### PR DESCRIPTION
To Do:

- [ ] Get tests to pass
- [ ] Hammer out the exact semantics for `p2` paths that end with `..` or `.` (which `rm` rejects and `shutil.rmtree()` does the wrong thing on before erroring), especially when the component before that is a symlink.